### PR TITLE
Prevent user from changing resource owner

### DIFF
--- a/app/routes/item_routes.js
+++ b/app/routes/item_routes.js
@@ -52,7 +52,7 @@ router.post('/items', requireToken, (req, res, next) => {
 router.patch('/items/:id', requireToken, removeBlanks, (req, res, next) => {
   // if the client attempts to change the `owner` property by including a new
   // owner, prevent that by deleting that key/value pair
-  // delete req.body.example.owner
+  delete req.body.item.owner
 
   Item.findById(req.params.id)
     .then(handle404)


### PR DESCRIPTION
Added line to delete item.user upon patch to prevent user from
changing their own resource to have another owner

Please review!! @lancemahon @elinagorshkova @mrodrz7 